### PR TITLE
fix error in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ First, install the module:
 
 Afterwards, usage is as simple as shown in the following example:
 ```javascript
-var password = require('password-hash-and-salt');
+var password = require('happn-password-hash-and-salt');
 
 var myuser = [];
 


### PR DESCRIPTION
Since your package is named `happn-password-hash-and-salt` you need to adjust the `require()` to match the correct package name